### PR TITLE
Use 'chart_folder_path' when cleaning up chart output.

### DIFF
--- a/avionix/chart/chart_builder.py
+++ b/avionix/chart/chart_builder.py
@@ -62,8 +62,8 @@ class ChartBuilder:
             )
 
     def __delete_chart_directory(self):
-        if os.path.exists(self.chart_info.name):
-            shutil.rmtree(self.chart_info.name)
+        if os.path.exists(self.chart_folder_path):
+            shutil.rmtree(self.chart_folder_path)
 
     def generate_chart(self):
         """


### PR DESCRIPTION
The current behavior ignores the `output_directory` provided to the chart builder and is potentially dangerous in that it deletes unrelated directory trees!