### PR TITLE
Strip extraneous whitespace from headers in command output.

### DIFF
--- a/avionix/testing/helpers.py
+++ b/avionix/testing/helpers.py
@@ -48,7 +48,7 @@ def parse_output_to_dict(output: str):
         if line.strip():
             values = _split_using_locations(value_locations, line)
             value_rows.append(values)
-    return {names[i]: row for i, row in enumerate(zip(*value_rows))}
+    return {names[i].strip(): row for i, row in enumerate(zip(*value_rows))}
 
 
 class KubectlGetException(Exception):


### PR DESCRIPTION
In my usage, when calling `chart.is_installed` wherein the `helm list` output is parsed, the `NAME` header has a space before the `\t` character. This leads to the parsing failing and an exception being thrown. This fixes the parsing behavior by stripping whitespace from the headers.
