### PR TITLE
Don't pin PyYAML to specific version.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     description="A package for soldifying kubernetes structure and development by "
     "using objects and code rather than yaml",
     python_requires=">=3.6.1",
-    install_requires=["pyyaml==5.3.1"],
+    install_requires=["pyyaml >=5.3, <5.4"],
     project_urls={
         "Source Code": "https://github.com/zbrookle/avionix",
         "Documentation": "https://github.com/zbrookle/avionix",


### PR DESCRIPTION
Currently PyYaml is pinned to `5.3.1` in the `setup.py` configuration. This seems unnecessary, but I left the version specifier range to the 5.3 minor version in case that was intentional.