### PR TITLE
Add dependencies private repo

### DIFF
--- a/avionix/_process_utils.py
+++ b/avionix/_process_utils.py
@@ -5,7 +5,7 @@ from subprocess import STDOUT, CalledProcessError, check_output
 def custom_check_output(command: str):
     info(f"Running command: {command}")
     try:
-        output = check_output(command.split(" "), stderr=STDOUT).decode("utf-8")
+        output = check_output(command, stderr=STDOUT).decode("utf-8")
     except CalledProcessError as err:
         error(err.output.decode("utf-8"))
         raise err

--- a/avionix/chart/chart_dependency.py
+++ b/avionix/chart/chart_dependency.py
@@ -53,10 +53,12 @@ class ChartDependency(HelmYaml):
         credential_args = ""
 
         if self.__repo_username is not None:
-            credential_args += f" --username \"{self.__repo_username}\""
+            username = self.__sanitize_arg(self.__repo_username)
+            credential_args += f" --username \"{username}\""
 
         if self.__repo_password is not None:
-            credential_args += f" --password \"{self.__repo_password}\""
+            password = self.__sanitize_arg(self.__repo_password)
+            credential_args += f" --password \"{password}\""
 
         custom_check_output(f"helm repo add {credential_args} {self.__local_repo_name} {self.repository}")
 

--- a/avionix/chart/chart_dependency.py
+++ b/avionix/chart/chart_dependency.py
@@ -67,3 +67,7 @@ class ChartDependency(HelmYaml):
     @property
     def local_repo_name(self):
         return self.__local_repo_name
+
+    @staticmethod
+    def __sanitize_arg(arg: str):
+        return arg.replace("\"", "\\\"")

--- a/avionix/chart/chart_dependency.py
+++ b/avionix/chart/chart_dependency.py
@@ -18,6 +18,10 @@ class ChartDependency(HelmYaml):
         file for this dependency
     :param is_local: If *True*, the repo will not be added on install. This setting \
         is required if using a local chart as a dependency
+    :param repo_username: If specified. The command to add the repo will include  \
+        the username
+    :param repo_password: If specified. The command to add the repo will include  \
+        the password
     """
 
     def __init__(
@@ -28,6 +32,8 @@ class ChartDependency(HelmYaml):
         local_repo_name: str,
         values: Optional[dict] = None,
         is_local: bool = False,
+        repo_username: Optional[str] = None,
+        repo_password: Optional[dict] = None,
     ):
         self.name = name
         self.version = version
@@ -35,6 +41,8 @@ class ChartDependency(HelmYaml):
         self.__values = values
         self.__local_repo_name = local_repo_name
         self.__is_local = is_local
+        self.__repo_username = repo_username
+        self.__repo_password = repo_password
 
     def get_values_yaml(self) -> dict:
         if self.__values:
@@ -42,7 +50,15 @@ class ChartDependency(HelmYaml):
         return {}
 
     def add_repo(self):
-        custom_check_output(f"helm repo add {self.__local_repo_name} {self.repository}")
+        credential_args = ""
+
+        if self.__repo_username is not None:
+            credential_args += f" --username {self.__repo_username}"
+
+        if self.__repo_password is not None:
+            credential_args += f" --password {self.__repo_password}"
+
+        custom_check_output(f"helm repo add {credential_args} {self.__local_repo_name} {self.repository}")
 
     @property
     def is_local(self):

--- a/avionix/chart/chart_dependency.py
+++ b/avionix/chart/chart_dependency.py
@@ -33,7 +33,7 @@ class ChartDependency(HelmYaml):
         values: Optional[dict] = None,
         is_local: bool = False,
         repo_username: Optional[str] = None,
-        repo_password: Optional[dict] = None,
+        repo_password: Optional[str] = None,
     ):
         self.name = name
         self.version = version

--- a/avionix/chart/chart_dependency.py
+++ b/avionix/chart/chart_dependency.py
@@ -53,10 +53,10 @@ class ChartDependency(HelmYaml):
         credential_args = ""
 
         if self.__repo_username is not None:
-            credential_args += f" --username {self.__repo_username}"
+            credential_args += f" --username \"{self.__repo_username}\""
 
         if self.__repo_password is not None:
-            credential_args += f" --password {self.__repo_password}"
+            credential_args += f" --password \"{self.__repo_password}\""
 
         custom_check_output(f"helm repo add {credential_args} {self.__local_repo_name} {self.repository}")
 


### PR DESCRIPTION
The goal of this PR is to support private repository for dependencies. If you add repo_username and repo_password to ChartDependency. It will add the credentials to the add command.