### PR TITLE
Fix 0-value integers ignored in the output charts

### DIFF
--- a/avionix/yaml/yaml_handling.py
+++ b/avionix/yaml/yaml_handling.py
@@ -8,7 +8,7 @@ from yaml import dump
 
 def is_empty_yaml(value):
     # If value is None, [], {} do not include value
-    return not value and not isinstance(value, (bool, str))
+    return not value and not isinstance(value, (bool, str, int))
 
 
 def is_private_var(key: str):


### PR DESCRIPTION
This change fixes the bug where the 0-value integers are ignored while generating the chart.

I faced this issue while trying to set the `batch/v1.Job.spec.backoffLimit` to 0 to avoid retrying failed jobs, but the current implementation will entirely remove the `backoff_limit` attribute which will tell Kubernetes to fall back to its default value (which is 6).