### PR TITLE
is_installed property uses helm status command

### DIFF
--- a/avionix/chart/chart_builder.py
+++ b/avionix/chart/chart_builder.py
@@ -330,7 +330,14 @@ class ChartBuilder:
         :return: True if chart with the given name is already installed in the chart \
             builders namespace, else False
         """
-        installations = get_helm_installations(self.namespace)
-        if not installations:
+        command = f"helm status {self.chart_info.name}"
+        if self.namespace is not None:
+            command += f" -n {self.namespace}"
+        try:
+            output = subprocess.check_call(command.split(" "),
+                                           stdout=subprocess.DEVNULL,
+                                           stderr=subprocess.DEVNULL)
+        except subprocess.CalledProcessError:
             return False
-        return self.chart_info.name in installations["NAME"]
+        else:
+            return True


### PR DESCRIPTION
This pull request aims to fix a bug in the `is_installed` property of the chart builder class:
the property uses the command `helm list` and check if the release is in the list of releases, but this command will only show a limited number of results (256) and the releases after the 256th will result as uninstalled. This could be fixed setting an higher limit, but this is not scalable in cluster with a great number of releases.
So we made the property use the `helm status` command and check for the return code, which is faster and fixed the bug